### PR TITLE
Fix version file URL property

### DIFF
--- a/RecoverableEmergencyKerbalTransport.version
+++ b/RecoverableEmergencyKerbalTransport.version
@@ -1,6 +1,6 @@
 {
   "NAME": "RecoverableEmergencyKerbalTransport",
-  "URL": "http:/ksp.spacetux.net/avc/RecoverableEmergencyKerbalTransport",
+  "URL": "https://github.com/linuxgurugamer/REKT/raw/master/RecoverableEmergencyKerbalTransport.version",
   "DOWNLOAD": "https://github.com/linuxgurugamer/REKT/releases/tag/v0.4.5",
   "CHANGE_LOG_URL": "https://github.com/linuxgurugamer/REKT/blob/master/Changelog.txt",
   "VERSION": {


### PR DESCRIPTION
This mod's version file's URL property is missing a `/` character after `http:/`, and its host of `ksp.spacetux.net` doesn't seem to contain version files anymore.

Now it points to the copy on GitHub.